### PR TITLE
fix: Normalize path to avoid issue on Windows

### DIFF
--- a/src/Console/ConsoleScoper.php
+++ b/src/Console/ConsoleScoper.php
@@ -180,9 +180,9 @@ final class ConsoleScoper
         Assert::notNull($commonDirectoryPath);
 
         $mapFiles = static fn (array $inputFileTuple) => [
-            $inputFileTuple[0],
+            Path::normalize($inputFileTuple[0]),
             $inputFileTuple[1],
-            $outputDir.str_replace($commonDirectoryPath, '', $inputFileTuple[0]),
+            $outputDir.str_replace($commonDirectoryPath, '', Path::normalize($inputFileTuple[0])),
         ];
 
         return [


### PR DESCRIPTION
Related to https://github.com/humbug/php-scoper/issues/810